### PR TITLE
update dockerfile, shrink image size

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,18 +1,23 @@
 # Use an official Python runtime as a parent image
-FROM python:3.11
+FROM python:3.11-slim
+
+RUN pip install poetry==1.8.3
 
 # Set the working directory in the container
 WORKDIR /app
 
-# Install Poetry
-RUN curl -sSL https://install.python-poetry.org | python3 -
-ENV PATH="/root/.local/bin:$PATH"
-    
+ENV PATH="/root/.local/bin:$PATH" \
+    POETRY_NO_INTERACTION=1 \
+    POETRY_VIRTUALENVS_IN_PROJECT=1 \
+    POETRY_VIRTUALENVS_CREATE=1 \
+    POETRY_CACHE_DIR=/tmp/poetry_cache
+
 # Copy Poetry files
 COPY pyproject.toml poetry.lock ./
-    
+
 # Install dependencies
-RUN poetry install 
+RUN poetry install --without dev --no-root && \
+    rm -rf ${POETRY_CACHE_DIR}
 
 # Copy the rest of the application code into the container
 COPY . .


### PR DESCRIPTION
This adds a couple of caching tricks to the dockerfile to try to get it to reduce the size. It also uses the `-slim` version of the Python base image, which is quite a bit smaller. Everything needed is installed by either pip or poetry, so we don't need the full image.